### PR TITLE
Remove setting env vars to allow finetuning to work

### DIFF
--- a/src/reference_implementations/setup_gpu_worker.sh
+++ b/src/reference_implementations/setup_gpu_worker.sh
@@ -10,10 +10,4 @@ source ${VIRTUAL_ENV}/bin/activate
 # without these, tensorflow or jax will not detect any GPU cards.
 # we point to the specific cuda and cudnn versions available on the cluster.
 
-export PATH="${VIRTUAL_ENV}/bin:/pkgs/cuda-11.3/bin:$PATH"
-
-export LD_LIBRARY_PATH="/scratch/ssd001/pkgs/cudnn-11.4-v8.2.4.15/lib64:/scratch/ssd001/pkgs/cuda-11.3/targets/x86_64-linux/lib"
-
-export XLA_FLAGS='--xla_gpu_simplify_all_fp_conversions --xla_gpu_all_reduce_combine_threshold_bytes=136314880 ${XLA_FLAGS}'
-
 echo "Using Python from: $(which python)"


### PR DESCRIPTION
# PR Type
Fix

# Short Description
[Ticket: Run all hugging_face_basics examples](https://app.clickup.com/t/8686z3rqa)
All notebooks run just fine, need to remove the lines of code setting environment variables in the setup worker script to allow fine-tuning scripts to work.